### PR TITLE
Don't build benchmark by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,9 @@ subdir('contrib')
 subdir('src')
 subdir('tests')
 subdir('doc')
-subdir('benchmark')
+if get_option('benchmark')
+    subdir('benchmark')
+endif
 
 configure_file(input : 'coati.sublime-project.in',
   output : 'coati.sublime-project',

--- a/meson.build
+++ b/meson.build
@@ -29,10 +29,12 @@ project('COATI', 'cpp',
 
 subdir('contrib')
 subdir('src')
-subdir('tests')
+if get_option('test')
+  subdir('tests')
+endif
 subdir('doc')
 if get_option('benchmark')
-    subdir('benchmark')
+  subdir('benchmark')
 endif
 
 configure_file(input : 'coati.sublime-project.in',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('benchmark', type : 'boolean', value : false, description : 'Build benchmark tests')
+option('test', type : 'boolean', value : true, description : 'Build unit tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('benchmark', type : 'boolean', value : false, description : 'Build benchmark tests')


### PR DESCRIPTION
Add build option to enable building benchmark tests. Default behavior is disabled.
Usage: `meson setup builddir -Dbenchmark=true`.
Fixes #8 .