### PR TITLE
Update json format

### DIFF
--- a/src/include/coati/io.hpp
+++ b/src/include/coati/io.hpp
@@ -46,7 +46,8 @@ coati::Matrixf parse_matrix_csv(const std::string& file);
 // Read sequences and names in any supported format.
 coati::data_t read_input(coati::alignment_t& aln);
 // Write sequences and names in any suppported format.
-void write_output(coati::data_t& data, const coati::VectorFstStdArc& aln = {});
+void write_output(coati::alignment_t& aln,
+                  const coati::VectorFstStdArc& fst = {});
 
 }  // namespace coati::io
 #endif

--- a/src/include/coati/json.hpp
+++ b/src/include/coati/json.hpp
@@ -38,6 +38,9 @@ coati::data_t read_json(std::istream& in, bool marginal);
 // Write content of coati::data_t to json format.
 void write_json(coati::data_t& json, std::ostream& out,
                 const VectorFstStdArc& aln = {});
+// Write content of coati::data_t to json format for coati sample.
+void write_json(coati::data_t& data, std::ostream& out, size_t iter,
+                size_t sample_size);
 }  // namespace coati
 
 #endif

--- a/src/include/coati/mutation_fst.hpp
+++ b/src/include/coati/mutation_fst.hpp
@@ -48,7 +48,7 @@ VectorFstStdArc indel(float gap_open, float gap_extend,
                       const std::vector<float>& pi);
 // Add arc to FST.
 void add_arc(VectorFstStdArc& fst, int src, int dest, int ilabel = 0,
-             int olabel = 0, float weight = 1.0);
+             int olabel = 0, float score = 1.0);
 // Create FSA (acceptor) from a sequence.
 bool acceptor(const std::string_view content, VectorFstStdArc& accept);
 // Optimize FST: remove epsilons, determinize, and minimize.

--- a/src/include/coati/structs.hpp
+++ b/src/include/coati/structs.hpp
@@ -68,7 +68,7 @@ class data_t {
     std::filesystem::path path;        /*!< path to input file */
     std::vector<std::string> names;    /*!< names of fasta sequences */
     std::vector<std::string> seqs;     /*!< fasta sequences */
-    float_t weight{0.f};               /*!< alignment weight */
+    float_t score{0.f};                /*!< alignment score */
     std::vector<VectorFstStdArc> fsts; /*!< sequences as FSTs */
     file_type_t out_file;              /*!< path to alignment output file */
 
@@ -80,7 +80,7 @@ class data_t {
         : path{std::move(p)},
           names{std::move(n)},
           seqs{std::move(s)},
-          weight{w},
+          score{w},
           fsts{std::move(f)},
           out_file{o} {}
 
@@ -129,8 +129,8 @@ class alignment_t {
                                0.f, 0.f, 0.f}; /*!< GTR sigma parameters */
     Matrixf subst_matrix;                      /*!< substitution matrix */
     VectorFstStdArc subst_fst;                 /*!< substitution FST */
-    std::filesystem::path output;      /*!< path to alignment output file */
-    std::filesystem::path weight_file; /*!< file to output alignment weight */
+    std::filesystem::path output;     /*!< path to alignment output file */
+    std::filesystem::path score_file; /*!< file to output alignment score */
     bool score{false}; /*!< if true an input alignment is scored */
     AmbiguousNucs amb = AmbiguousNucs::AVG;
 

--- a/src/include/coati/structs.hpp
+++ b/src/include/coati/structs.hpp
@@ -70,19 +70,16 @@ class data_t {
     std::vector<std::string> seqs;     /*!< fasta sequences */
     float_t score{0.f};                /*!< alignment score */
     std::vector<VectorFstStdArc> fsts; /*!< sequences as FSTs */
-    file_type_t out_file;              /*!< path to alignment output file */
 
     data_t() = default;
     explicit data_t(std::filesystem::path p, std::vector<std::string> n = {},
                     std::vector<std::string> s = {}, float_t w = 0.f,
-                    std::vector<VectorFstStdArc> f = {},
-                    const std::filesystem::path& o = "")
+                    std::vector<VectorFstStdArc> f = {})
         : path{std::move(p)},
           names{std::move(n)},
           seqs{std::move(s)},
           score{w},
-          fsts{std::move(f)},
-          out_file{o} {}
+          fsts{std::move(f)} {}
 
     /** \brief Return number of names/sequences */
     std::size_t size() {
@@ -129,9 +126,8 @@ class alignment_t {
                                0.f, 0.f, 0.f}; /*!< GTR sigma parameters */
     Matrixf subst_matrix;                      /*!< substitution matrix */
     VectorFstStdArc subst_fst;                 /*!< substitution FST */
-    std::filesystem::path output;     /*!< path to alignment output file */
-    std::filesystem::path score_file; /*!< file to output alignment score */
-    bool score{false}; /*!< if true an input alignment is scored */
+    std::filesystem::path output; /*!< path to alignment output file */
+    bool score{false};            /*!< if true an input alignment is scored */
     AmbiguousNucs amb = AmbiguousNucs::AVG;
 
     /** \brief Return true if model selected is marginal (marginal or m-ecm) */

--- a/src/lib/align_fst.cc
+++ b/src/lib/align_fst.cc
@@ -97,21 +97,11 @@ bool fst_alignment(coati::alignment_t& aln) {
     fst::ShortestDistance(aln_path, &distance);
     aln.data.score = distance[0].Value();
 
-    if(!aln.score_file.empty()) {
-        std::ofstream out_w;
-
-        // append score and fasta file name info in file
-        out_w.open(aln.score_file, std::ios::app | std::ios::out);
-        out_w << aln.data.path.string() << "," << aln.model << ","
-              << distance[0] << std::endl;
-        out_w.close();
-    }
-
     // topsort path FST
     fst::TopSort(&aln_path);
 
     // write alignment
-    coati::io::write_output(aln.data, aln_path);
+    coati::io::write_output(aln, aln_path);
     return true;
 }
 
@@ -165,29 +155,24 @@ TEST_CASE("fst_alignment") {
     out << ">1\nCTCTGGATAGTG\n>2\nCTATAGTG\n";
     out.close();
 
-    SUBCASE("coati model, output fasta") {
+    SUBCASE("coati model, output json") {
         aln.model = "coati";
-        aln.score_file = "score.log";
-        aln.output = "test-fst-alignment.fasta";
+        aln.output = "test-fst-alignment.json";
 
         REQUIRE(fst_alignment(aln));
         std::ifstream infile(aln.output);  // input file
-        std::string s1, s2;
-
-        infile >> s1 >> s2;
-        CHECK_EQ(s1, ">1");
-        CHECK_EQ(s2, "CTCTGGATAGTG");
-
-        infile >> s1 >> s2;
-        CHECK_EQ(s1, ">2");
-        CHECK_EQ(s2, "CT----ATAGTG");
-
-        std::ifstream inscore(aln.score_file);
-        std::string s;
-        inscore >> s;
-        REQUIRE(std::filesystem::remove(aln.score_file));
+        std::stringstream ss;
+        ss << infile.rdbuf();
+        std::string s1 = ss.str();
+        CHECK_EQ(s1, R"({
+  "alignment": {
+    "1": "CTCTGGATAGTG",
+    "2": "CT----ATAGTG"
+  },
+  "score": 9.312972068786621
+}
+)");
         REQUIRE(std::filesystem::remove(aln.output));
-        CHECK_EQ(s, "test-fst.fasta,coati,9.31297");
     }
 
     SUBCASE("coati model, output phylip") {
@@ -216,7 +201,6 @@ TEST_CASE("fst_alignment") {
 
     SUBCASE("dna model") {
         aln.model = "dna";
-        aln.score_file = "score.log";
         aln.output = "test-fst-alignment.fasta";
 
         REQUIRE(fst_alignment(aln));
@@ -232,17 +216,10 @@ TEST_CASE("fst_alignment") {
         CHECK_EQ(s1, ">2");
         CHECK_EQ(s2, "CT----ATAGTG");
         REQUIRE(std::filesystem::remove(aln.output));
-
-        std::ifstream inscore(aln.score_file);
-        std::string s;
-        inscore >> s;
-        REQUIRE(std::filesystem::remove(aln.score_file));
-        CHECK_EQ(s, "test-fst.fasta,dna,9.31894");
     }
 
     SUBCASE("ecm model") {
         aln.model = "ecm";
-        aln.score_file = "score.log";
         aln.output = "test-fst-alignment-ecm.fasta";
 
         REQUIRE(fst_alignment(aln));
@@ -258,17 +235,10 @@ TEST_CASE("fst_alignment") {
         CHECK_EQ(s2, "CT----ATAGTG");
 
         REQUIRE(std::filesystem::remove(aln.output));
-
-        std::ifstream inscore(aln.score_file);
-        std::string s;
-        inscore >> s;
-        REQUIRE(std::filesystem::remove(aln.score_file));
-        CHECK_EQ(s, "test-fst.fasta,ecm,9.31288");
     }
 
     SUBCASE("Unknown model") {
         aln.model = "unknown";
-        aln.score_file = "score.log";
         aln.output = "test-fst-alignment.fasta";
 
         CHECK_THROWS_AS(coati::utils::set_subst(aln), std::invalid_argument);

--- a/src/lib/align_marginal.cc
+++ b/src/lib/align_marginal.cc
@@ -94,10 +94,10 @@ bool marg_alignment(coati::alignment_t& aln) {
     }
     coati::traceback(work, anc, des, aln, aln.gap.len);
 
-    if(!aln.weight_file.empty()) {  // save weight and filename
-        out_w.open(aln.weight_file, std::ios::app | std::ios::out);
+    if(!aln.score_file.empty()) {  // save score and filename
+        out_w.open(aln.score_file, std::ios::app | std::ios::out);
         out_w << aln.data.path.string() << "," << aln.model << ","
-              << aln.data.weight << std::endl;
+              << aln.data.score << std::endl;
         out_w.close();
     }
 
@@ -152,15 +152,15 @@ TEST_CASE("marg_alignment") {
         REQUIRE(std::filesystem::remove(aln.output));
         REQUIRE(std::filesystem::remove("test-marg.fasta"));
 
-        if(!aln.weight_file.empty()) {
-            std::ifstream inweight(aln.weight_file);
+        if(!aln.score_file.empty()) {
+            std::ifstream inscore(aln.score_file);
             std::string s;  // NOLINT(clang-diagnostic-unused-variable)
-            inweight >> s;
+            inscore >> s;
             // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
             std::size_t start = s.find_last_of(',');
-            CHECK_EQ(std::stof(s.substr(start + 1)), expected.weight);
+            CHECK_EQ(std::stof(s.substr(start + 1)), expected.score);
             CHECK_EQ(s.substr(0, start), "test-marg.fasta,marginal");
-            REQUIRE(std::filesystem::remove(aln.weight_file));
+            REQUIRE(std::filesystem::remove(aln.score_file));
         }
     };
 
@@ -199,11 +199,11 @@ TEST_CASE("marg_alignment") {
         std::string file{">1\nCTCTGGATAGTG\n>2\nCTATAGTG\n"};
         aln.data.path = "test-marg.fasta";
         aln.model = "marginal";
-        aln.weight_file = "score.log";
+        aln.score_file = "score.log";
         aln.output = "test-marg_alignment-fasta.fasta";
 
         expected = data_t("", {">1", ">2"}, {"CTCTGGATAGTG", "CT----ATAGTG"});
-        expected.weight = 1.51294f;
+        expected.score = 1.51294f;
 
         test_fasta(aln, expected, file);
     }
@@ -276,23 +276,23 @@ TEST_CASE("marg_alignment") {
         std::string file{">1\nCTCTGGATAGTG\n>2\nCTATAGTR\n"};
         aln.data.path = "test-marg.fasta";
         aln.model = "marginal";
-        aln.weight_file = "score.log";
+        aln.score_file = "score.log";
         aln.output = "test-marg_alignment_ambiguous.fa";
 
         expected = data_t("", {">1", ">2"}, {"CTCTGGATAGTG", "CT----ATAGTR"});
-        expected.weight = -1.03892f;  // AVG
+        expected.score = -1.03892f;  // AVG
         test_fasta(aln, expected, file);
     }
     SUBCASE("Alignment with ambiguous nucleotides - BEST") {
         std::string file{">1\nCTCTGGATAGTG\n>2\nCTATAGTR\n"};
         aln.data.path = "test-marg.fasta";
         aln.model = "marginal";
-        aln.weight_file = "score.log";
+        aln.score_file = "score.log";
         aln.output = "test-marg_alignment_ambiguous.fa";
         aln.amb = coati::AmbiguousNucs::BEST;
 
         expected = data_t("", {">1", ">2"}, {"CTCTGGATAGTG", "CT----ATAGTR"});
-        expected.weight = 1.51294f;  // BEST
+        expected.score = 1.51294f;  // BEST
         test_fasta(aln, expected, file);
     }
     SUBCASE("Alignment with gap length multiple of 3 - fail") {
@@ -326,7 +326,7 @@ TEST_CASE("marg_alignment") {
         out.close();
         aln.data.path = "test-marg.fasta";
         aln.model = "marginal";
-        aln.weight_file = "";
+        aln.score_file = "";
         aln.output = "test-marg_alignment-score.fasta";
         aln.score = true;
 
@@ -340,7 +340,7 @@ TEST_CASE("marg_alignment") {
         out.close();
         aln.data.path = "test-marg.fasta";
         aln.model = "marginal";
-        aln.weight_file = "";
+        aln.score_file = "";
         aln.output = "test-marg_alignment-score-f.fasta";
         aln.score = true;
 
@@ -456,23 +456,23 @@ float alignment_score(const coati::alignment_t& aln,
     std::transform(pi.cbegin(), pi.cend(), pi.begin(),
                    [](auto value) { return ::logf(value); });
 
-    float weight{0.f};
+    float score{0.f};
     int state{0}, ngap{0};
     for(size_t i = 0; i < seqs[0].length(); i++) {
         switch(state) {
         case 0:  // subsitution
             if(seqs[0][i] == '-') {
                 // insertion;
-                weight += gap_open;
+                score += gap_open;
                 state = 2;
                 ngap++;
             } else if(seqs[1][i] == '-') {
                 // deletion;
-                weight += no_gap + gap_open;
+                score += no_gap + gap_open;
                 state = 1;
             } else {
                 // match/mismatch;
-                weight +=
+                score +=
                     2 * no_gap + p_marg(seq_pair[0][i - ngap], seq_pair[1][i]);
             }
             break;
@@ -482,10 +482,10 @@ float alignment_score(const coati::alignment_t& aln,
                     "Insertion after deletion is not modeled.");
             } else if(seqs[1][i] == '-') {
                 // deletion_ext
-                weight += gap_extend;
+                score += gap_extend;
             } else {
                 // match/mismatch
-                weight +=
+                score +=
                     gap_stop + p_marg(seq_pair[0][i - ngap], seq_pair[1][i]);
                 state = 0;
             }
@@ -493,28 +493,28 @@ float alignment_score(const coati::alignment_t& aln,
         case 2:  // insertion
             if(seqs[0][i] == '-') {
                 // insertion_ext
-                weight += gap_extend;
+                score += gap_extend;
                 ngap++;
             } else if(seqs[1][i] == '-') {
                 // deletion
-                weight += gap_stop + gap_open;
+                score += gap_stop + gap_open;
                 state = 1;
             } else {
                 // match/mismatch
-                weight += gap_stop + no_gap +
-                          p_marg(seq_pair[0][i - ngap], seq_pair[1][i]);
+                score += gap_stop + no_gap +
+                         p_marg(seq_pair[0][i - ngap], seq_pair[1][i]);
                 state = 0;
             }
             break;
         }
     }
-    // terminal state weight
+    // terminal state score
     if(state == 0) {
-        weight += no_gap;
+        score += no_gap;
     } else if(state == 2) {
-        weight += gap_stop;
+        score += gap_stop;
     }
-    return weight;
+    return score;
 }
 
 /// @private
@@ -602,28 +602,11 @@ void marg_sample(coati::alignment_t& aln, size_t sample_size, random_t& rand) {
     coati::align_pair_work_t work;
     coati::viterbi(work, seq_pair[0], seq_pair[1], aln);
 
-    out << "[" << std::endl;
     // sample and print as many aligments as required (sample_size)
     for(size_t i = 0; i < sample_size; ++i) {
         coati::sampleback(work, anc, des, aln, aln.gap.len, rand);
-
-        out << "  {\n    \"aln\": {\n";
-        out << "      \"" << aln.name(0) << "\": ";
-        out << "\"" << aln.seq(0) << "\",\n";
-        out << "      \"" << aln.name(1) << "\": ";
-        out << "\"" << aln.seq(1) << "\"\n";
-        out << "    },\n";
-        out << "    \"weight\": " << ::expf(aln.data.weight) << ",\n";
-        out << "    \"log_weight\": " << aln.data.weight << "\n";
-        if(i < sample_size - 1) {
-            out << "  },";
-        } else {
-            out << "  }";
-        }
-        out << std::endl;
+        write_json(aln.data, out, i, sample_size);
     }
-
-    out << "]" << std::endl;
 }
 
 /// @private
@@ -641,8 +624,7 @@ TEST_CASE("marg_sample") {
                                 const std::string& seq2,
                                 const std::vector<std::string>& expected_s1,
                                 const std::vector<std::string>& expected_s2,
-                                const std::vector<std::string>& weight,
-                                const std::vector<std::string>& lweight) {
+                                const std::vector<std::string>& lscore) {
         // set seed
         coati::random_t rand;
         const std::vector<std::string> s42{{"42"}};
@@ -666,17 +648,16 @@ TEST_CASE("marg_sample") {
 
         check_line_eq(infile, "[");
         for(size_t i = 0; i < reps; ++i) {
-            check_line_eq(infile, "  {");
-            check_line_eq(infile, "    \"aln\": {");
-            check_line_eq(infile, R"(      "A": ")" + expected_s1[i] + "\",");
-            check_line_eq(infile, R"(      "B": ")" + expected_s2[i] + "\"");
-            check_line_eq(infile, "    },");
-            check_line_eq(infile, "    \"weight\": " + weight[i] + ",");
-            check_line_eq(infile, "    \"log_weight\": " + lweight[i]);
+            check_line_eq(infile, "{");
+            check_line_eq(infile, "  \"alignment\": {");
+            check_line_eq(infile, R"(    "A": ")" + expected_s1[i] + "\",");
+            check_line_eq(infile, R"(    "B": ")" + expected_s2[i] + "\"");
+            check_line_eq(infile, "  },");
+            check_line_eq(infile, "  \"score\": " + lscore[i]);
             if(i < reps - 1) {
-                check_line_eq(infile, "  },");
+                check_line_eq(infile, "},");
             } else {
-                check_line_eq(infile, "  }");
+                check_line_eq(infile, "}");
             }
         }
         check_line_eq(infile, "]");
@@ -688,23 +669,21 @@ TEST_CASE("marg_sample") {
     SUBCASE("sample size 1") {
         std::vector<std::string> seq1{"CC--CCCC"};
         std::vector<std::string> seq2{"CCCCCCCC"};
-        std::vector<std::string> weight{"0.031239"};
-        std::vector<std::string> lweight{"-3.46609"};
-        test("CCCCCC", "CCCCCCCC", seq1, seq2, weight, lweight);
+        std::vector<std::string> lscore{"-3.466088056564331"};
+        test("CCCCCC", "CCCCCCCC", seq1, seq2, lscore);
     }
     SUBCASE("sample size 1 - deletion") {
         std::vector<std::string> seq1{"CCCCCC"};
         std::vector<std::string> seq2{"CCCC--"};
-        std::vector<std::string> weight{"0.856821"};
-        std::vector<std::string> lweight{"-0.154526"};
-        test("CCCCCC", "CCCC", seq1, seq2, weight, lweight);
+        std::vector<std::string> lscore{"-0.1545257419347763"};
+        test("CCCCCC", "CCCC", seq1, seq2, lscore);
     }
     SUBCASE("sample size 3") {
         std::vector<std::string> seq1{"CC--CCCC", "CCCCCC--", "CCCCC--C"};
         std::vector<std::string> seq2{"CCCCCCCC", "CCCCCCCC", "CCCCCCCC"};
-        std::vector<std::string> weight{"0.031239", "0.499854", "0.249923"};
-        std::vector<std::string> lweight{"-3.46609", "-0.69344", "-1.3866"};
-        test("CCCCCC", "CCCCCCCC", seq1, seq2, weight, lweight);
+        std::vector<std::string> lscore{
+            "-3.466088056564331", "-0.6934397220611572", "-1.3866020441055298"};
+        test("CCCCCC", "CCCCCCCC", seq1, seq2, lscore);
     }
     SUBCASE("length of reference not multiple of 3") {
         coati::random_t rand;

--- a/src/lib/align_msa.cc
+++ b/src/lib/align_msa.cc
@@ -43,8 +43,6 @@ namespace coati {
  * @retval true successful run.
  */
 bool ref_indel_alignment(coati::alignment_t& input) {
-    coati::data_t aligned;
-
     if(!input.is_marginal()) {
         throw std::invalid_argument("MSA only supports marginal models.");
     }
@@ -54,8 +52,6 @@ bool ref_indel_alignment(coati::alignment_t& input) {
     if(input.data.size() < 3) {
         throw std::invalid_argument("At least three sequences required.");
     }
-
-    aligned.out_file = input.data.out_file;
 
     // read newick tree file
     std::string newick = coati::tree::read_newick(input.tree);
@@ -104,17 +100,20 @@ bool ref_indel_alignment(coati::alignment_t& input) {
     merge_alignments(visited, tree, nodes_ins, inode_indexes);
 
     // transfer result data nodes_ins[ROOT] --> aln && order sequences
+    coati::alignment_t aln;
+    aln.output = input.output;
+
     auto root = tree[ref_pos].parent;
     for(const auto& name : input.data.names) {
         auto it = find(nodes_ins[root].names.begin(),
                        nodes_ins[root].names.end(), name);
         auto index = distance(nodes_ins[root].names.begin(), it);
-        aligned.names.push_back(nodes_ins[root].names[index]);
-        aligned.seqs.push_back(nodes_ins[root].sequences[index]);
+        aln.data.names.push_back(nodes_ins[root].names[index]);
+        aln.data.seqs.push_back(nodes_ins[root].sequences[index]);
     }
 
     // write alignment
-    coati::io::write_output(aligned);
+    coati::io::write_output(aln);
     return true;
 }
 
@@ -143,7 +142,7 @@ TEST_CASE("ref_indel_alignment") {
 
         REQUIRE(ref_indel_alignment(aln));
 
-        std::ifstream infile(aln.data.out_file.path);
+        std::ifstream infile(aln.output);
         std::string s1, s2;
 
         infile >> s1 >> s2;
@@ -174,7 +173,7 @@ TEST_CASE("ref_indel_alignment") {
 
         REQUIRE(ref_indel_alignment(aln));
 
-        std::ifstream infile(aln.data.out_file.path);
+        std::ifstream infile(aln.output);
         std::string s1, s2;
 
         infile >> s1 >> s2;
@@ -235,7 +234,7 @@ TEST_CASE("ref_indel_alignment") {
         aln.output = "test-fst-complex-tree.fa";
         REQUIRE(ref_indel_alignment(aln));
 
-        std::ifstream infile(aln.data.out_file.path);
+        std::ifstream infile(aln.output);
         std::string s1, s2;
 
         infile >> s1 >> s2;

--- a/src/lib/format.cc
+++ b/src/lib/format.cc
@@ -71,7 +71,7 @@ int format_sequences(coati::format_t& format, coati::alignment_t& aln) {
     }
 
     // output formatted sequences
-    coati::io::write_output(aln.data);
+    coati::io::write_output(aln);
     return EXIT_SUCCESS;
 }
 
@@ -210,14 +210,14 @@ TEST_CASE("format_sequences") {
 
     // NOLINTNEXTLINE(misc-unused-parameters)
     auto test_format_fasta = [](args_t args, data_t expected) {
-        args.aln.data.out_file = {"test-format-seqs.fa", ".fa"};
-        if(std::filesystem::exists(args.aln.data.out_file.path)) {
-            std::filesystem::remove(args.aln.data.out_file.path);
+        args.aln.output = "test-format-seqs.fa";
+        if(std::filesystem::exists(args.aln.output)) {
+            std::filesystem::remove(args.aln.output);
         }
 
         REQUIRE_EQ(coati::format_sequences(args.format, args.aln), 0);
 
-        std::ifstream infile(args.aln.data.out_file.path);
+        std::ifstream infile(args.aln.output);
         std::string s1, s2;
 
         for(size_t i = 0; i < expected.size(); ++i) {
@@ -226,19 +226,19 @@ TEST_CASE("format_sequences") {
             CHECK(s2 == expected.seqs[i]);
         }
 
-        CHECK(std::filesystem::remove(args.aln.data.out_file.path));
+        CHECK(std::filesystem::remove(args.aln.output));
     };
 
     // NOLINTNEXTLINE(misc-unused-parameters)
     auto test_format_phylip = [](args_t args, data_t expected) {
-        args.aln.data.out_file = {"test-format-seqs.phy", ".phy"};
-        if(std::filesystem::exists(args.aln.data.out_file.path)) {
-            std::filesystem::remove(args.aln.data.out_file.path);
+        args.aln.output = "test-format-seqs.phy";
+        if(std::filesystem::exists(args.aln.output)) {
+            std::filesystem::remove(args.aln.output);
         }
 
         REQUIRE_EQ(coati::format_sequences(args.format, args.aln), 0);
 
-        std::ifstream infile(args.aln.data.out_file.path);
+        std::ifstream infile(args.aln.output);
         std::string s1, s2;
 
         infile >> s1 >> s2;
@@ -251,7 +251,7 @@ TEST_CASE("format_sequences") {
             CHECK(s2 == expected.seqs[i]);
         }
 
-        CHECK(std::filesystem::remove(args.aln.data.out_file.path));
+        CHECK(std::filesystem::remove(args.aln.output));
     };
 
     SUBCASE("fasta-multiple-3") {

--- a/src/lib/mutation_fst.cc
+++ b/src/lib/mutation_fst.cc
@@ -266,23 +266,23 @@ TEST_CASE("indel") {
  * @param[in] dest int destination state.
  * @param[in] ilabel int input label.
  * @param[in] olabel int output label.
- * @param[in] weight float weight of the arc.
+ * @param[in] score float score of the arc.
  */
 void add_arc(VectorFstStdArc& fst, int src, int dest, int ilabel, int olabel,
-             float weight) {
-    if(weight == 1.0) {
-        weight = 0.0;
-    } else if(weight == 0.0) {
-        weight = static_cast<float>(INT_MAX);
+             float score) {
+    if(score == 1.0) {
+        score = 0.0;
+    } else if(score == 0.0) {
+        score = static_cast<float>(INT_MAX);
     } else {
-        weight = -logf(weight);
+        score = -logf(score);
     }
 
     if(fst.NumStates() <= dest) {
         fst.AddState();
-        fst.AddArc(src, fst::StdArc(ilabel, olabel, weight, dest));
+        fst.AddArc(src, fst::StdArc(ilabel, olabel, score, dest));
     } else {
-        fst.AddArc(src, fst::StdArc(ilabel, olabel, weight, dest));
+        fst.AddArc(src, fst::StdArc(ilabel, olabel, score, dest));
     }
 }
 

--- a/src/lib/utils.cc
+++ b/src/lib/utils.cc
@@ -108,7 +108,7 @@ void set_options_alignpair(CLI::App& app, coati::args_t& args) {
                  "Use 2nd seq as reference (default: 1st seq)")
         ->excludes(opt_ref)
         ->group("Advanced options");
-    app.add_option("-l,--weight", args.aln.weight_file,
+    app.add_option("-l,--score-file", args.aln.score_file,
                    "Write alignment score to file");
     app.add_flag("-s,--score", args.aln.score,
                  "Score input alignment and exit");
@@ -154,12 +154,12 @@ TEST_CASE("parse_arguments_alignpair") {
 
     std::vector<const char*> argv;
     std::vector<std::string> cli_args = {
-        "alignpair", "test.fasta", "-m",    "fst",        "-t",    "0.2",
-        "-r",        "A",          "-l",    "weight.log", "-s",    "-o",
-        "out.phy",   "-g",         "0.015", "-e",         "0.009", "-w",
-        "0.21",      "-p",         "0.15",  "0.35",       "0.35",  "0.15",
-        "-k",        "3",          "-x",    "0.1",        "0.1",   "0.1",
-        "0.1",       "0.1",        "0.1",   "-a",         "AVG"};
+        "alignpair", "test.fasta", "-m",    "fst",       "-t",    "0.2",
+        "-r",        "A",          "-l",    "score.log", "-s",    "-o",
+        "out.phy",   "-g",         "0.015", "-e",        "0.009", "-w",
+        "0.21",      "-p",         "0.15",  "0.35",      "0.35",  "0.15",
+        "-k",        "3",          "-x",    "0.1",       "0.1",   "0.1",
+        "0.1",       "0.1",        "0.1",   "-a",        "AVG"};
     argv.reserve(cli_args.size() + 1);
     for(auto& arg : cli_args) {
         argv.push_back(arg.c_str());
@@ -171,7 +171,7 @@ TEST_CASE("parse_arguments_alignpair") {
     CHECK_EQ(args.aln.model, "fst");
     CHECK_EQ(args.aln.br_len, 0.2f);
     CHECK_EQ(args.aln.refs, "A");
-    CHECK_EQ(args.aln.weight_file, "weight.log");
+    CHECK_EQ(args.aln.score_file, "score.log");
     CHECK(args.aln.score);
     CHECK_EQ(args.aln.output, "out.phy");
     CHECK_EQ(args.aln.gap.open, 0.015f);
@@ -626,7 +626,7 @@ TEST_CASE("extract_file_type") {
 /**
  * @brief Convert alignment FST to std::string sequences.
  *
- * @param[in] data coati::data_t sequences, names, fst, weight information.
+ * @param[in] data coati::data_t sequences, names, fst, score information.
  * @param[in] aln coati::alignment_t alignment object.
  */
 void fst_to_seqs(coati::data_t& data, const VectorFstStdArc& aln) {

--- a/src/lib/utils.cc
+++ b/src/lib/utils.cc
@@ -108,8 +108,6 @@ void set_options_alignpair(CLI::App& app, coati::args_t& args) {
                  "Use 2nd seq as reference (default: 1st seq)")
         ->excludes(opt_ref)
         ->group("Advanced options");
-    app.add_option("-l,--score-file", args.aln.score_file,
-                   "Write alignment score to file");
     app.add_flag("-s,--score", args.aln.score,
                  "Score input alignment and exit");
     app.add_option("-o,--output", args.aln.output, "Alignment output file");
@@ -154,12 +152,11 @@ TEST_CASE("parse_arguments_alignpair") {
 
     std::vector<const char*> argv;
     std::vector<std::string> cli_args = {
-        "alignpair", "test.fasta", "-m",    "fst",       "-t",    "0.2",
-        "-r",        "A",          "-l",    "score.log", "-s",    "-o",
-        "out.phy",   "-g",         "0.015", "-e",        "0.009", "-w",
-        "0.21",      "-p",         "0.15",  "0.35",      "0.35",  "0.15",
-        "-k",        "3",          "-x",    "0.1",       "0.1",   "0.1",
-        "0.1",       "0.1",        "0.1",   "-a",        "AVG"};
+        "alignpair", "test.fasta", "-m",   "fst",     "-t",   "0.2",   "-r",
+        "A",         "-s",         "-o",   "out.phy", "-g",   "0.015", "-e",
+        "0.009",     "-w",         "0.21", "-p",      "0.15", "0.35",  "0.35",
+        "0.15",      "-k",         "3",    "-x",      "0.1",  "0.1",   "0.1",
+        "0.1",       "0.1",        "0.1",  "-a",      "AVG"};
     argv.reserve(cli_args.size() + 1);
     for(auto& arg : cli_args) {
         argv.push_back(arg.c_str());
@@ -171,7 +168,6 @@ TEST_CASE("parse_arguments_alignpair") {
     CHECK_EQ(args.aln.model, "fst");
     CHECK_EQ(args.aln.br_len, 0.2f);
     CHECK_EQ(args.aln.refs, "A");
-    CHECK_EQ(args.aln.score_file, "score.log");
     CHECK(args.aln.score);
     CHECK_EQ(args.aln.output, "out.phy");
     CHECK_EQ(args.aln.gap.open, 0.015f);

--- a/tests/libcoati-doctest-tests.txt
+++ b/tests/libcoati-doctest-tests.txt
@@ -15,6 +15,7 @@ read_input
 write_output
 read_json
 write-json
+write-json-sample
 mg94_p
 marginal_p
 gtr_q


### PR DESCRIPTION
Update json format to be consistent between `alignpair` and `sample`.
Update argument weight to score.
New format:
```json
{
  "aln": {
    "1": "CTCTGGATAGTG",
    "2": "CT----ATAGTG"
  },
  "score": 0.994785
}
```

Fixes #10.