### PR TITLE
Fix ambiguous nucleotide probabilities

### DIFF
--- a/src/include/coati/mutation_coati.hpp
+++ b/src/include/coati/mutation_coati.hpp
@@ -44,7 +44,7 @@ coati::Matrixf marginal_p(const coati::Matrixf& P,
                           const std::vector<coati::float_t>& pi,
                           const coati::AmbiguousNucs amb);
 // Probabilities for ambiguous nucs in marginal model using averages.
-void ambiguous_avg_p(coati::Matrixf& p);
+void ambiguous_sum_p(coati::Matrixf& p);
 // Probabilities for ambiguous nucs in marginal model taking best prob.
 void ambiguous_best_p(coati::Matrixf& p);
 // Create GTR substitution model matrix.

--- a/src/include/coati/utils.hpp
+++ b/src/include/coati/utils.hpp
@@ -157,5 +157,9 @@ static inline float_t log_sum_exp(float_t a, float_t b) {
     return x + log1p_exp(y);
 }
 
+static inline float_t log_sum_exp(float_t a, float_t b, float_t c) {
+    return log_sum_exp(log_sum_exp(a, b), c);
+}
+
 }  // namespace coati::utils
 #endif

--- a/src/lib/mutation_coati.cc
+++ b/src/lib/mutation_coati.cc
@@ -193,7 +193,7 @@ coati::Matrixf marginal_p(const coati::Matrixf& P,
     }
 
     if(amb == AmbiguousNucs::AVG) {
-        ambiguous_avg_p(p);
+        ambiguous_sum_p(p);
     } else {
         ambiguous_best_p(p);
     }
@@ -230,24 +230,40 @@ TEST_CASE("marginal_p") {
  * @param[in,out] p coati::Matrixf marginal substitution matrix.
  *
  */
-void ambiguous_avg_p(coati::Matrixf& p) {
+void ambiguous_sum_p(coati::Matrixf& p) {
+    using coati::utils::log_sum_exp;
     size_t row{0};
     for(int cod = 0; cod < 61; cod++) {
         for(size_t pos = 0; pos < 3; pos++) {
             row = cod * 3 + pos;
-
-            p(row, 4) = (p(row, 0) + p(row, 2)) / 2;  // R: purine       A or G
-            p(row, 5) = (p(row, 1) + p(row, 3)) / 2;  // Y: pyrimidine   C or T
-            p(row, 6) = (p(row, 0) + p(row, 1)) / 2;  // M: amino group  A or C
-            p(row, 7) = (p(row, 2) + p(row, 3)) / 2;  // K: keto group   G or T
-            p(row, 8) = (p(row, 1) + p(row, 2)) / 2;  // S: strong inter C or G
-            p(row, 9) = (p(row, 0) + p(row, 3)) / 2;  // W: weak interac A or T
-            p(row, 10) = (p(row, 1) + p(row, 2) + p(row, 3)) / 3;  // B: not A
-            p(row, 11) = (p(row, 0) + p(row, 2) + p(row, 3)) / 3;  // D: not C
-            p(row, 12) = (p(row, 0) + p(row, 1) + p(row, 3)) / 3;  // H: not G
-            p(row, 13) = (p(row, 0) + p(row, 1) + p(row, 2)) / 3;  // V: not T
-            p(row, 14) =
-                (p(row, 0) + p(row, 1) + p(row, 2) + p(row, 3)) / 4;  // N: any
+            // R: purine       A or G
+            p(row, 4) = log_sum_exp(p(row, 0), p(row, 2));
+            // Y: pyrymidine   C or T
+            p(row, 5) = log_sum_exp(p(row, 1), p(row, 3));
+            // M: amino group  A or C
+            p(row, 6) = log_sum_exp(p(row, 0), p(row, 1));
+            // K: keto group   G or T
+            p(row, 7) = log_sum_exp(p(row, 2), p(row, 3));
+            // S: strong inter C or G
+            p(row, 8) = log_sum_exp(p(row, 1), p(row, 2));
+            // W: weak interac A or T
+            p(row, 9) = log_sum_exp(p(row, 0), p(row, 3));
+            // B: not A
+            p(row, 10) =
+                log_sum_exp(log_sum_exp(p(row, 1), p(row, 2)), p(row, 3));
+            // D: not C
+            p(row, 11) =
+                log_sum_exp(log_sum_exp(p(row, 0), p(row, 2)), p(row, 3));
+            // H: not G
+            p(row, 12) =
+                log_sum_exp(log_sum_exp(p(row, 0), p(row, 1)), p(row, 3));
+            // V: not T
+            p(row, 13) =
+                log_sum_exp(log_sum_exp(p(row, 0), p(row, 1)), p(row, 2));
+            // N: any
+            p(row, 14) = log_sum_exp(
+                log_sum_exp(log_sum_exp(p(row, 0), p(row, 1)), p(row, 2)),
+                p(row, 3));
         }
     }
 }

--- a/src/lib/mutation_coati.cc
+++ b/src/lib/mutation_coati.cc
@@ -249,21 +249,16 @@ void ambiguous_sum_p(coati::Matrixf& p) {
             // W: weak interac A or T
             p(row, 9) = log_sum_exp(p(row, 0), p(row, 3));
             // B: not A
-            p(row, 10) =
-                log_sum_exp(log_sum_exp(p(row, 1), p(row, 2)), p(row, 3));
+            p(row, 10) = log_sum_exp(p(row, 1), p(row, 2), p(row, 3));
             // D: not C
-            p(row, 11) =
-                log_sum_exp(log_sum_exp(p(row, 0), p(row, 2)), p(row, 3));
+            p(row, 11) = log_sum_exp(p(row, 0), p(row, 2), p(row, 3));
             // H: not G
-            p(row, 12) =
-                log_sum_exp(log_sum_exp(p(row, 0), p(row, 1)), p(row, 3));
+            p(row, 12) = log_sum_exp(p(row, 0), p(row, 1), p(row, 3));
             // V: not T
-            p(row, 13) =
-                log_sum_exp(log_sum_exp(p(row, 0), p(row, 1)), p(row, 2));
+            p(row, 13) = log_sum_exp(p(row, 0), p(row, 1), p(row, 2));
             // N: any
             p(row, 14) = log_sum_exp(
-                log_sum_exp(log_sum_exp(p(row, 0), p(row, 1)), p(row, 2)),
-                p(row, 3));
+                log_sum_exp(p(row, 0), p(row, 1), p(row, 2)), p(row, 3));
         }
     }
 }


### PR DESCRIPTION
This calculates the substitution probabilities correctly for ambiguous nucleotides on the marginal model. Previously math didn't consider that the probabilities were already in log space.
