### PR TITLE
Fix exceptions and handle lower-case in more places.

### DIFF
--- a/src/include/coati/utils.hpp
+++ b/src/include/coati/utils.hpp
@@ -93,7 +93,7 @@ using sequence_pair_t = std::vector<std::basic_string<unsigned char>>;
 
 // Hamming distance between two codons.
 int cod_distance(uint8_t cod1, uint8_t cod2);
-// Get a codon's position in the codon list (AAA->0, AAAC->1 .. TTT->63).
+// Get a codon's position in the codon list (AAA->0, AAC->1, ..., TTT->63).
 int cod_int(const std::string_view codon);
 // Setup command line options for coati-alignpair.
 void set_options_alignpair(CLI::App& app, coati::args_t& args);

--- a/src/lib/mutation_fst.cc
+++ b/src/lib/mutation_fst.cc
@@ -304,11 +304,9 @@ void add_arc(VectorFstStdArc& fst, int src, int dest, int ilabel, int olabel,
  * @retval true if run successfully.
  */
 bool acceptor(const std::string_view content, VectorFstStdArc& accept) {
-    std::map<char, int> syms = {{'-', 0},
-                                {'A', 1}, {'C', 2}, {'G', 3},
-                                {'T', 4}, {'U', 4}, {'N', 5},
-                                {'a', 1}, {'c', 2}, {'g', 3},
-                                {'t', 4}, {'u', 4}, {'n', 5}};
+    std::map<char, int> syms = {
+        {'-', 0}, {'A', 1}, {'C', 2}, {'G', 3}, {'T', 4}, {'U', 4}, {'N', 5},
+        {'a', 1}, {'c', 2}, {'g', 3}, {'t', 4}, {'u', 4}, {'n', 5}};
 
     // Add initial state
     accept.AddState();

--- a/src/lib/mutation_fst.cc
+++ b/src/lib/mutation_fst.cc
@@ -304,8 +304,11 @@ void add_arc(VectorFstStdArc& fst, int src, int dest, int ilabel, int olabel,
  * @retval true if run successfully.
  */
 bool acceptor(const std::string_view content, VectorFstStdArc& accept) {
-    std::map<char, int> syms = {{'-', 0}, {'A', 1}, {'C', 2}, {'G', 3},
-                                {'T', 4}, {'U', 4}, {'N', 5}};
+    std::map<char, int> syms = {{'-', 0},
+                                {'A', 1}, {'C', 2}, {'G', 3},
+                                {'T', 4}, {'U', 4}, {'N', 5},
+                                {'a', 1}, {'c', 2}, {'g', 3},
+                                {'t', 4}, {'u', 4}, {'n', 5}};
 
     // Add initial state
     accept.AddState();

--- a/src/lib/utils.cc
+++ b/src/lib/utils.cc
@@ -50,7 +50,8 @@ int cod_distance(uint8_t cod1, uint8_t cod2) {
 }
 
 /**
- * @brief Get a codon's position in the codon list (AAA->0, AAC->1, ..., TTT->63).
+ * @brief Get a codon's position in the codon list (AAA->0, AAC->1, ...,
+ * TTT->63).
  *
  * @details Each nucleotide is converted to its position in nucleotide list
  * (A = 0, C = 1, G = 2, T = 3). Then we apply the following:
@@ -477,12 +478,13 @@ sequence_pair_t marginal_seq_encoding(const std::string_view anc,
     for(size_t i = 0; i < anc.size(); i += 3) {
         auto cod = cod_int(anc.substr(i, i + 2));
         if(cod == -1) {
-           throw std::invalid_argument(
+            throw std::invalid_argument(
                 "Ambiguous nucleotides in ancestor/reference.");
         }
         // if stop codon - throw error
         if(cod == 48 || cod == 50 || cod == 56) {
-            throw std::invalid_argument("Early stop codon in ancestor/reference.");
+            throw std::invalid_argument(
+                "Early stop codon in ancestor/reference.");
         }
         cod = cod64_to_61(cod);
         cod *= 3;
@@ -946,7 +948,6 @@ TEST_CASE("trim_end_stops") {
     test_tri({"AAA", "C"}, {"AAA", "C"}, {"", ""});
     test_tri({"AAATGA", "C"}, {"AAA", "C"}, {"TGA", ""});
     test_tri({"AAA", "ctaa"}, {"AAA", "c"}, {"", "taa"});
-
 }
 // GCOVR_EXCL_STOP
 


### PR DESCRIPTION
- Fix exception thrown if trim_end_gaps is run on a sequence with less than 3 characters.
- Handle lower-case and rna sequences in trim_end_gaps.
- Return -1 instead of throwing an exception if an ambiguous nucleotide is found by cod_int.
- Support lower-case symbols in FST models.

Possible issue: The FST models will convert lower-case input to upper case.