### PR TITLE
Use semiring operations and update end weights on marginal model

### DIFF
--- a/src/include/coati/align_pair.hpp
+++ b/src/include/coati/align_pair.hpp
@@ -172,8 +172,12 @@ void viterbi(align_pair_work_t &work, const seq_view_t &a, const seq_view_t &b,
 void viterbi_mem(align_pair_work_mem_t &work, const seq_view_t &a,
                  const seq_view_t &b, const alignment_t &aln);
 // Implementation of traceback algorithm.
+template <class S>
 void traceback(const align_pair_work_mem_t &work, const std::string &a,
                const std::string &b, alignment_t &aln, size_t look_back);
+void traceback_viterbi(const align_pair_work_mem_t &work, const std::string &a,
+                       const std::string &b, alignment_t &aln,
+                       size_t look_back);
 // Traceback with sampling.
 void sampleback(const align_pair_work_t &work, const std::string &a,
                 const std::string &b, alignment_t &aln, size_t look_back,

--- a/src/include/coati/semiring.hpp
+++ b/src/include/coati/semiring.hpp
@@ -47,9 +47,7 @@ class linear {
     static constexpr float times(float x, float y, Args... args) {
         return times(times(x, y), args...);
     }
-    static constexpr float power(float x, size_t y) {
-        return std::pow(x, y);
-    }
+    static constexpr float power(float x, size_t y) { return std::pow(x, y); }
     static constexpr float zero() { return 0.0f; }
     static constexpr float one() { return 1.0f; }
 };

--- a/src/include/coati/semiring.hpp
+++ b/src/include/coati/semiring.hpp
@@ -44,6 +44,10 @@ class linear {
     static constexpr float times(float first, Args... args) {
         return first * times(args...);
     }
+    static constexpr float power(float x, float y) { return std::pow(x, y); }
+    static constexpr float power(float x, size_t y) {
+        return std::pow(x, static_cast<float>(y));
+    }
     static constexpr float zero() { return 0.0f; }
     static constexpr float one() { return 1.0f; }
 };
@@ -66,6 +70,10 @@ class log {
     template <typename... Args>
     static constexpr float times(float first, Args... args) {
         return first + times(args...);
+    }
+    static constexpr float power(float x, float y) { return x * y; }
+    static constexpr float power(float x, size_t y) {
+        return x * static_cast<float>(y);
     }
     static constexpr float zero() {
         return std::numeric_limits<float_t>::lowest();
@@ -94,6 +102,10 @@ class tropical {
     template <typename... Args>
     static constexpr float times(float first, Args... args) {
         return first + times(args...);
+    }
+    static constexpr float power(float x, float y) { return x * y; }
+    static constexpr float power(float x, size_t y) {
+        return x * static_cast<float>(y);
     }
     static constexpr float zero() {
         return std::numeric_limits<float_t>::lowest();

--- a/src/include/coati/semiring.hpp
+++ b/src/include/coati/semiring.hpp
@@ -38,15 +38,17 @@ namespace coati::semiring {
 class linear {
    public:
     static constexpr float plus(float x, float y) { return x + y; }
-    static constexpr float plus(float x, float y, float z) { return x + y + z; }
-    static constexpr float times(float x) { return x; }
     template <typename... Args>
-    static constexpr float times(float first, Args... args) {
-        return first * times(args...);
+    static constexpr float plus(float x, float y, Args... args) {
+        return plus(plus(x, y), args...);
     }
-    static constexpr float power(float x, float y) { return std::pow(x, y); }
+    static constexpr float times(float x, float y) { return x * y; }
+    template <typename... Args>
+    static constexpr float times(float x, float y, Args... args) {
+        return times(times(x, y), args...);
+    }
     static constexpr float power(float x, size_t y) {
-        return std::pow(x, static_cast<float>(y));
+        return std::pow(x, y);
     }
     static constexpr float zero() { return 0.0f; }
     static constexpr float one() { return 1.0f; }
@@ -63,15 +65,15 @@ class log {
     static float plus(float x, float y) {
         return coati::utils::log_sum_exp(x, y);
     }
-    static float plus(float x, float y, float z) {
-        return coati::utils::log_sum_exp(coati::utils::log_sum_exp(x, y), z);
-    }
-    static constexpr float times(float x) { return x; }
     template <typename... Args>
-    static constexpr float times(float first, Args... args) {
-        return first + times(args...);
+    static constexpr float plus(float x, float y, Args... args) {
+        return plus(plus(x, y), args...);
     }
-    static constexpr float power(float x, float y) { return x * y; }
+    static constexpr float times(float x, float y) { return x + y; }
+    template <typename... Args>
+    static constexpr float times(float x, float y, Args... args) {
+        return times(times(x, y), args...);
+    }
     static constexpr float power(float x, size_t y) {
         return x * static_cast<float>(y);
     }
@@ -95,15 +97,15 @@ class log {
 class tropical {
    public:
     static constexpr float plus(float x, float y) { return std::max(x, y); }
-    static constexpr float plus(float x, float y, float z) {
-        return std::max(std::max(x, y), z);
-    }
-    static constexpr float times(float x) { return x; }
     template <typename... Args>
-    static constexpr float times(float first, Args... args) {
-        return first + times(args...);
+    static constexpr float plus(float x, float y, Args... args) {
+        return plus(plus(x, y), args...);
     }
-    static constexpr float power(float x, float y) { return x * y; }
+    static constexpr float times(float x, float y) { return x + y; }
+    template <typename... Args>
+    static constexpr float times(float x, float y, Args... args) {
+        return times(times(x, y), args...);
+    }
     static constexpr float power(float x, size_t y) {
         return x * static_cast<float>(y);
     }

--- a/src/include/coati/semiring.hpp
+++ b/src/include/coati/semiring.hpp
@@ -40,6 +40,12 @@ class linear {
     static constexpr float plus(float x, float y) { return x + y; }
     static constexpr float plus(float x, float y, float z) { return x + y + z; }
     static constexpr float times(float x, float y) { return x * y; }
+    static constexpr float times(float x, float y, float z) {
+        return x * y * z;
+    }
+    static constexpr float times(float w, float x, float y, float z) {
+        return w * x * y * z;
+    }
     static constexpr float zero() { return 0.0f; }
     static constexpr float one() { return 1.0f; }
 };
@@ -47,7 +53,7 @@ class linear {
  * @brief Log semiring class.
  *
  * |         Set          |     +     | * | + neutral element | * neutral elem |
- * | Reals U {-INF, +INF} | logSumExp | + |        +INF       |         0      |
+ * | Reals U {-INF, +INF} | logSumExp | + |        -INF       |         0      |
  *
  */
 class log {
@@ -59,7 +65,15 @@ class log {
         return coati::utils::log_sum_exp(coati::utils::log_sum_exp(x, y), z);
     }
     static constexpr float times(float x, float y) { return x + y; }
-    static constexpr float zero() { return static_cast<float>(INT_MAX); }
+    static constexpr float times(float x, float y, float z) {
+        return x + y + z;
+    }
+    static constexpr float times(float w, float x, float y, float z) {
+        return w + x + y + z;
+    }
+    static constexpr float zero() {
+        return std::numeric_limits<float_t>::lowest();
+    }
     static constexpr float one() { return 0.0f; }
 
     static float from_linearf(float x) { return ::logf(x); }
@@ -71,17 +85,25 @@ class log {
  * @brief Tropical semiring class.
  *
  * |         Set          |  +  | * | + neutral element | * neutral element |
- * | Reals U {-INF, +INF} | max | + |        +INF       |         0      |
+ * | Reals U {-INF, +INF} | max | + |        -INF       |         0      |
  *
  */
 class tropical {
    public:
     static constexpr float plus(float x, float y) { return std::max(x, y); }
     static constexpr float plus(float x, float y, float z) {
-        return std::max(plus(x, y), z);
+        return std::max(std::max(x, y), z);
     }
     static constexpr float times(float x, float y) { return x + y; }
-    static constexpr float zero() { return static_cast<float>(INT_MAX); }
+    static constexpr float times(float x, float y, float z) {
+        return x + y + z;
+    }
+    static constexpr float times(float w, float x, float y, float z) {
+        return w + x + y + z;
+    }
+    static constexpr float zero() {
+        return std::numeric_limits<float_t>::lowest();
+    }
     static constexpr float one() { return 0.0f; }
 
     static float from_linearf(float x) { return ::logf(x); }

--- a/src/include/coati/semiring.hpp
+++ b/src/include/coati/semiring.hpp
@@ -39,12 +39,10 @@ class linear {
    public:
     static constexpr float plus(float x, float y) { return x + y; }
     static constexpr float plus(float x, float y, float z) { return x + y + z; }
-    static constexpr float times(float x, float y) { return x * y; }
-    static constexpr float times(float x, float y, float z) {
-        return x * y * z;
-    }
-    static constexpr float times(float w, float x, float y, float z) {
-        return w * x * y * z;
+    static constexpr float times(float x) { return x; }
+    template <typename... Args>
+    static constexpr float times(float first, Args... args) {
+        return first * times(args...);
     }
     static constexpr float zero() { return 0.0f; }
     static constexpr float one() { return 1.0f; }
@@ -64,12 +62,10 @@ class log {
     static float plus(float x, float y, float z) {
         return coati::utils::log_sum_exp(coati::utils::log_sum_exp(x, y), z);
     }
-    static constexpr float times(float x, float y) { return x + y; }
-    static constexpr float times(float x, float y, float z) {
-        return x + y + z;
-    }
-    static constexpr float times(float w, float x, float y, float z) {
-        return w + x + y + z;
+    static constexpr float times(float x) { return x; }
+    template <typename... Args>
+    static constexpr float times(float first, Args... args) {
+        return first + times(args...);
     }
     static constexpr float zero() {
         return std::numeric_limits<float_t>::lowest();
@@ -94,12 +90,10 @@ class tropical {
     static constexpr float plus(float x, float y, float z) {
         return std::max(std::max(x, y), z);
     }
-    static constexpr float times(float x, float y) { return x + y; }
-    static constexpr float times(float x, float y, float z) {
-        return x + y + z;
-    }
-    static constexpr float times(float w, float x, float y, float z) {
-        return w + x + y + z;
+    static constexpr float times(float x) { return x; }
+    template <typename... Args>
+    static constexpr float times(float first, Args... args) {
+        return first + times(args...);
     }
     static constexpr float zero() {
         return std::numeric_limits<float_t>::lowest();

--- a/src/lib/align_fst.cc
+++ b/src/lib/align_fst.cc
@@ -277,6 +277,15 @@ TEST_CASE("fst_alignment") {
 
         CHECK_THROWS_AS(coati::fst_alignment(aln), std::invalid_argument);
     }
+    SUBCASE("Ambiguous codon in ancestor - fail") {
+        std::ofstream out;
+        out.open("test-fst.fasta");
+        REQUIRE(out);
+        out << ">1\nCTCTGN\n>2\nCTATGGTG\n";
+        out.close();
+
+        CHECK_THROWS_AS(coati::fst_alignment(aln), std::invalid_argument);
+    }
     SUBCASE("Sequence with end stop codon") {
         std::ofstream out;
         out.open("test-fst.fasta");

--- a/src/lib/align_marginal.cc
+++ b/src/lib/align_marginal.cc
@@ -73,7 +73,7 @@ bool marg_alignment(coati::alignment_t& aln) {
         std::cerr << "ERROR: " << e.what() << std::endl;
         return false;
     }
-    coati::traceback(work, anc, des, aln, aln.gap.len);
+    coati::traceback_viterbi(work, anc, des, aln, aln.gap.len);
 
     // handle end stop codons
     coati::utils::restore_end_stops(aln.data, aln.gap);
@@ -548,7 +548,7 @@ void marg_sample(coati::alignment_t& aln, size_t sample_size, random_t& rand) {
     // set substitution matrix according to model
     coati::utils::set_subst(aln);
 
-    // dynamic programming pairwise alignment and traceback
+    // dynamic programming pairwise alignment and sampleback
     coati::align_pair_work_t work;
     coati::forward(work, seq_pair[0], seq_pair[1], aln);
 

--- a/src/lib/align_marginal.cc
+++ b/src/lib/align_marginal.cc
@@ -635,20 +635,20 @@ TEST_CASE("marg_sample") {
     SUBCASE("sample size 1") {
         std::vector<std::string> seq1{"CC--CCCC"};
         std::vector<std::string> seq2{"CCCCCCCC"};
-        std::vector<std::string> lscore{"-1.9466572999954224"};
+        std::vector<std::string> lscore{"-1.9466571807861328"};
         test("CCCCCC", "CCCCCCCC", seq1, seq2, lscore);
     }
     SUBCASE("sample size 1 - deletion") {
         std::vector<std::string> seq1{"CCCCCC"};
         std::vector<std::string> seq2{"--CCCC"};
-        std::vector<std::string> lscore{"-1.6172499656677246"};
+        std::vector<std::string> lscore{"-1.6172490119934082"};
         test("CCCCCC", "CCCC", seq1, seq2, lscore);
     }
     SUBCASE("sample size 3") {
         std::vector<std::string> seq1{"CC--CCCC", "CCCCCC--", "CCCC--CC"};
         std::vector<std::string> seq2{"CCCCCCCC", "CCCCCCCC", "CCCCCCCC"};
         std::vector<std::string> lscore{
-            "-1.9466572999954224", "-1.946657419204712", "-1.9466570615768433"};
+            "-1.9466571807861328", "-1.9466569423675537", "-1.9466572999954224"};
         test("CCCCCC", "CCCCCCCC", seq1, seq2, lscore);
     }
     SUBCASE("length of reference not multiple of 3") {

--- a/src/lib/align_marginal.cc
+++ b/src/lib/align_marginal.cc
@@ -647,8 +647,9 @@ TEST_CASE("marg_sample") {
     SUBCASE("sample size 3") {
         std::vector<std::string> seq1{"CC--CCCC", "CCCCCC--", "CCCC--CC"};
         std::vector<std::string> seq2{"CCCCCCCC", "CCCCCCCC", "CCCCCCCC"};
-        std::vector<std::string> lscore{
-            "-1.9466571807861328", "-1.9466569423675537", "-1.9466572999954224"};
+        std::vector<std::string> lscore{"-1.9466571807861328",
+                                        "-1.9466569423675537",
+                                        "-1.9466572999954224"};
         test("CCCCCC", "CCCCCCCC", seq1, seq2, lscore);
     }
     SUBCASE("length of reference not multiple of 3") {

--- a/src/lib/align_msa.cc
+++ b/src/lib/align_msa.cc
@@ -305,8 +305,8 @@ void align_leafs(coati::alignment_t& input, const coati::tree::tree_t& tree,
                 coati::utils::marginal_seq_encoding(pair_seqs[0], pair_seqs[1]);
             coati::align_pair_work_mem_t work;
             coati::viterbi_mem(work, seq_pair[0], seq_pair[1], input);
-            coati::traceback(work, pair_seqs[0], pair_seqs[1], aln,
-                             input.gap.len);
+            coati::traceback_viterbi(work, pair_seqs[0], pair_seqs[1], aln,
+                                     input.gap.len);
 
             // store insertion positions and type (open by default)
             SparseVectorInt ins = insertion_flags(aln.seq(0), aln.seq(1));

--- a/src/lib/align_pair.cc
+++ b/src/lib/align_pair.cc
@@ -32,15 +32,15 @@ namespace coati {
 // m -> m      (1-g)*(1-g)*P(b[j] | a[i])/P(b[j])
 // m -> d      (1-g)*g
 // m -> i      g
-// m -> END    1-g
+// m -> END    (1-g)*(1-g)
 // d -> m      1-e
 // d -> d      e
 // d -> i      0
-// d -> END    1
+// d -> END    1-e
 // i -> m      (1-e)*(1-g)
 // i -> d      (1-e)*g
 // i -> i      e
-// i -> END    (1-e)
+// i -> END    (1-e)*(1-g)
 
 // a is "ancestor"
 // b is "descendant"
@@ -134,9 +134,11 @@ void forward_impl(W &work, const seq_view_t &a, const seq_view_t &b,
     {
         // adjust the terminal state
         work.mch(len_a - 1, len_b - 1) =
-            S::times(work.mch(len_a - 1, len_b - 1), no_gap);
+            S::times(work.mch(len_a - 1, len_b - 1), 2 * no_gap);
         work.ins(len_a - 1, len_b - 1) =
-            S::times(work.ins(len_a - 1, len_b - 1), gap_stop);
+            S::times(work.ins(len_a - 1, len_b - 1), gap_stop, no_gap);
+        work.del(len_a - 1, len_b - 1) =
+            S::times(work.del(len_a - 1, len_b - 1), gap_stop);
     }
 }
 

--- a/src/lib/utils.cc
+++ b/src/lib/utils.cc
@@ -1029,6 +1029,13 @@ void process_triplet(coati::alignment_t& aln) {
         }
     }
 
+    // check that reference/ancestor doesnt have ambiguous nucs
+    auto pos = aln.seq(0).find_first_not_of("ACGTUacgtu");
+    if(pos != std::string::npos) {
+        throw std::invalid_argument(
+            "Ambiguous nucleotides in reference sequence not supported.");
+    }
+
     // handle ending stop codons
     trim_end_stops(aln.data);
 }


### PR DESCRIPTION
Use semiring operations in `forward_impl` and traceback algorithms.
Update end weights on marginal alignment to match probabilities of beginning and ending gaps.
Check for ambiguous nucleotides in FST alignment.